### PR TITLE
Endpoint get cards

### DIFF
--- a/src/cards/card.repository.ts
+++ b/src/cards/card.repository.ts
@@ -1,9 +1,10 @@
 import { Repository, EntityRepository } from 'typeorm';
 import { Card } from './card.entity';
 import { GetCardsFilterDto } from './dto/get-cards.dto';
+import { CardPreviewDto } from './dto/card-preview.dto';
 @EntityRepository(Card)
 export class CardRepository extends Repository<Card> {
-    getCards(filterDto: GetCardsFilterDto): Promise<Card[]> {
+    getCards(filterDto: GetCardsFilterDto): Promise<CardPreviewDto[]> {
         const { offset, limit, search } = filterDto;
         const query = this.createQueryBuilder('card');
         query.select('card.id, card.title, card.photo');
@@ -15,7 +16,7 @@ export class CardRepository extends Repository<Card> {
         query.orderBy('card.id', 'DESC');
         query.skip(offset);
         query.take(limit);
-        const cards = query.getRawMany();
-        return cards;
+        const headerCards: Promise<CardPreviewDto[]> = query.getRawMany();
+        return headerCards;
     }
 }

--- a/src/cards/card.repository.ts
+++ b/src/cards/card.repository.ts
@@ -1,7 +1,21 @@
 import { Repository, EntityRepository } from 'typeorm';
 import { Card } from './card.entity';
-
+import { GetCardsFilterDto } from './dto/get-cards.dto';
 @EntityRepository(Card)
 export class CardRepository extends Repository<Card> {
-
+    getCards(filterDto: GetCardsFilterDto): Promise<Card[]> {
+        const { offset, limit, search } = filterDto;
+        const query = this.createQueryBuilder('card');
+        query.select('card.id, card.title, card.photo');
+        if (search) {
+            query.where('card.title LIKE :search OR card.description LIKE :search', {
+                search: `%${search}%`,
+            });
+        }
+        query.orderBy('card.id', 'ASC');
+        query.skip(offset);
+        query.take(limit);
+        const cards = query.getRawMany();
+        return cards;
+    }
 }

--- a/src/cards/card.repository.ts
+++ b/src/cards/card.repository.ts
@@ -12,7 +12,7 @@ export class CardRepository extends Repository<Card> {
                 search: `%${search}%`,
             });
         }
-        query.orderBy('card.id', 'ASC');
+        query.orderBy('card.id', 'DESC');
         query.skip(offset);
         query.take(limit);
         const cards = query.getRawMany();

--- a/src/cards/cards.controller.ts
+++ b/src/cards/cards.controller.ts
@@ -1,6 +1,13 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, UsePipes, ValidationPipe, Query } from '@nestjs/common';
 import { CardsService } from './cards.service';
+import { GetCardsFilterDto } from './dto/get-cards.dto';
+import { Card } from './card.entity';
 @Controller()
 export class CardsController {
     constructor(private cardsService: CardsService) { }
+    @Get('v1/cards')
+    @UsePipes(new ValidationPipe({ transform: true }))
+    getCards(@Query() filterDto: GetCardsFilterDto): Promise<Card[]> {
+        return this.cardsService.getCards(filterDto);
+    }
 }

--- a/src/cards/cards.controller.ts
+++ b/src/cards/cards.controller.ts
@@ -1,13 +1,13 @@
 import { Controller, Get, UsePipes, ValidationPipe, Query } from '@nestjs/common';
 import { CardsService } from './cards.service';
 import { GetCardsFilterDto } from './dto/get-cards.dto';
-import { Card } from './card.entity';
+import { CardPreviewDto } from './dto/card-preview.dto';
 @Controller()
 export class CardsController {
     constructor(private cardsService: CardsService) { }
     @Get('v1/cards')
     @UsePipes(new ValidationPipe({ transform: true }))
-    getCards(@Query() filterDto: GetCardsFilterDto): Promise<Card[]> {
+    getCards(@Query() filterDto: GetCardsFilterDto): Promise<CardPreviewDto[]> {
         return this.cardsService.getCards(filterDto);
     }
 }

--- a/src/cards/cards.service.ts
+++ b/src/cards/cards.service.ts
@@ -2,9 +2,13 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Card } from './card.entity';
 import { CardRepository } from './card.repository';
+import { GetCardsFilterDto } from './dto/get-cards.dto';
 @Injectable()
 export class CardsService {
     constructor(
         @InjectRepository(Card) private cardRepository: CardRepository,
     ) { }
+    async getCards(filterDto: GetCardsFilterDto): Promise<Card[]> {
+        return this.cardRepository.getCards(filterDto);
+    }
 }

--- a/src/cards/cards.service.ts
+++ b/src/cards/cards.service.ts
@@ -3,12 +3,13 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Card } from './card.entity';
 import { CardRepository } from './card.repository';
 import { GetCardsFilterDto } from './dto/get-cards.dto';
+import { CardPreviewDto } from './dto/card-preview.dto';
 @Injectable()
 export class CardsService {
     constructor(
         @InjectRepository(Card) private cardRepository: CardRepository,
     ) { }
-    async getCards(filterDto: GetCardsFilterDto): Promise<Card[]> {
+    async getCards(filterDto: GetCardsFilterDto): Promise<CardPreviewDto[]> {
         return this.cardRepository.getCards(filterDto);
     }
 }

--- a/src/cards/dto/card-preview.dto.ts
+++ b/src/cards/dto/card-preview.dto.ts
@@ -1,0 +1,5 @@
+export class CardPreviewDto {
+    id: string;
+    title: string;
+    photo?: number;
+}

--- a/src/cards/dto/get-cards.dto.ts
+++ b/src/cards/dto/get-cards.dto.ts
@@ -1,0 +1,17 @@
+import { IsOptional, IsNotEmpty, IsNumber } from 'class-validator';
+import { Type } from 'class-transformer';
+export class GetCardsFilterDto {
+    @IsOptional()
+    @IsNumber()
+    @Type(() => Number)
+    limit: number = 15;
+
+    @IsOptional()
+    @IsNumber()
+    @Type(() => Number)
+    offset: number = 0;
+
+    @IsOptional()
+    @IsNotEmpty()
+    search: string;
+}


### PR DESCRIPTION
El endpoint get cards en caso de éxito retorna un array de vista previa de tarjetas (id, title, photo) en orden por id descendente para obtener los últimos creados primero. Opcionalmente se puede enviar como parámetro, además de offset (por defecto en 0) y limit (por defecto en 15), el parámetro search para poder filtrar las cards que incluyan en title o description la cadena de texto enviada.